### PR TITLE
Fixed high CPU usage for a period after typesetting

### DIFF
--- a/TeXnicle/PDFViewer/MHPDFView.m
+++ b/TeXnicle/PDFViewer/MHPDFView.m
@@ -31,45 +31,13 @@
 NSString * const MHPDFViewDidGainFocusNotification = @"MHPDFViewDidGainFocusNotification";
 NSString * const MHPDFViewDidLoseFocusNotification = @"MHPDFViewDidLoseFocusNotification";
 
-#define kPDF_UPDATE_INTERVAL 0.1
-
-@interface MHPDFView ()
-
-@property (strong) NSDate *lastUpdate;
-
-@end
-
 @implementation MHPDFView
 
 - (void) awakeFromNib
 {
   [super awakeFromNib];
   [self setBackgroundColor:[NSColor colorWithDeviceRed:230.0/255.0 green:230.0/255.0 blue:230.0/255.0 alpha:1.0]];
-  
-  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  [[[self enclosingScrollView] contentView] setPostsBoundsChangedNotifications:YES];
-  [nc addObserver:self
-         selector:@selector(handleFrameChangeNotification:)
-             name:NSViewBoundsDidChangeNotification
-           object:[[self enclosingScrollView] contentView]];
-  
 }
-
-- (void) handleFrameChangeNotification:(NSNotification*)aNote
-{
-  NSDate *now = [NSDate date];
-  
-  if (self.lastUpdate == nil ||
-      [now timeIntervalSinceDate:self.lastUpdate] > kPDF_UPDATE_INTERVAL) {
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self setNeedsDisplay:YES];
-      self.lastUpdate = now;
-    });
-    
-  }  
-}
-
 
 - (void)performFindPanelAction:(id)sender
 {


### PR DESCRIPTION
The implementation, as-was, updated _all_ PDF views whenever _any_ view changed bounds (`[[self enclosingScrollView] contentView]` was `nil`!!). When a typeset occurred, the console view would've spammed this notification, causing many PDF view updates. Interestingly, this seemed to cause an issue for _several seconds_ after the notifications stopped, and only for other windows than the one that you clicked typeset in.

The CPU usage would've varied on how many other windows were open. A few open would cause CPU usage to go between 100-200%.

The code I've removed in this pull request seemed to originate as a workaround for issues on 10.6.8 (see 928f9e9). Since that OS version is no longer supported, I thought it was safe to just remove it as it was just causing issues. I have not noticed other issues from doing this.