### PR TITLE
Fixed file template editor losing focus after each character entry

### DIFF
--- a/TeXnicle/src/TemplateEditor/TPTemplateEditorView.xib
+++ b/TeXnicle/src/TemplateEditor/TPTemplateEditorView.xib
@@ -111,9 +111,8 @@
                                 <size key="maxSize" width="534" height="10000000"/>
                                 <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 <connections>
-                                    <binding destination="48" name="value" keyPath="selection.Code" id="62">
+                                    <binding destination="48" name="value" keyPath="selection.Code" id="VEb-K0-Yyo">
                                         <dictionary key="options">
-                                            <bool key="NSContinuouslyUpdatesValue" value="YES"/>
                                             <bool key="NSValidatesImmediately" value="YES"/>
                                         </dictionary>
                                     </binding>

--- a/preferences/DBPrefsWindowController.m
+++ b/preferences/DBPrefsWindowController.m
@@ -60,22 +60,16 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 		
 		[self setCrossFade:NO];
 		[self setShiftSlowsAnimation:YES];
-		
-		NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-		[nc addObserver:self
-					 selector:@selector(handleWindowWillClose:)
-							 name:NSWindowWillCloseNotification
-						 object:self];
-		
 	}
 	return self;
 }
 
 
-- (void) handleWindowWillClose:(NSNotification*)aNote
+- (void)windowWillClose:(NSNotification *)notification
 {
-	// close color panel
-	
+	// Commit editing changes, by dropping focus from all controls.
+	// This makes sure the currently focused control sends a KVO update.
+	[[self window] makeFirstResponder:[self window]];
 }
 
 - (void)windowDidLoad
@@ -95,13 +89,6 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 	[[[self window] contentView] addSubview:contentSubview];
 	[[self window] setShowsToolbarButton:NO];
   [[self window] setDelegate:self];
-}
-
-
-
-
-- (void) dealloc {
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 
@@ -305,7 +292,7 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
 		frame.origin.y = NSHeight([contentSubview frame]) - NSHeight([newView bounds]);
 		[newView setFrame:frame];
 		[contentSubview addSubview:newView];
-		[[self window] setInitialFirstResponder:newView];
+		[[self window] makeFirstResponder:newView];
 
 		if (animate && [self crossFade])
 			[self crossFadeView:oldView withView:newView];

--- a/preferences/PrefsWindowController.m
+++ b/preferences/PrefsWindowController.m
@@ -130,6 +130,7 @@
 
 - (void) windowWillClose:(NSNotification *)notification
 {
+  [super windowWillClose:notification];
   if ([NSColorPanel sharedColorPanelExists]) {
     [[NSColorPanel sharedColorPanel] close];
   }


### PR DESCRIPTION
This was caused by the "continuously updates value" option under bindings. I see you noticed similar issues elsewhere in 5a09ed8.

Simply disabling it would've caused issues however, as the KVO would only update when the text view resigned as first responder. Closing the preferences window did not do this so any changes would be lost!

I have updated `DBPrefsWindowController` to address this. Now upon closing, it will make itself the first responder which in turn forces all other controls to resign as first responder. I've also adjusted the tab changing code to do a similar thing.

This change to `DBPrefsWindowController` means you should be able to use "continuously updates value" less now. I haven't touched anything but the file template editor however.